### PR TITLE
build: set GOARCH appropriately

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS builder
 WORKDIR /go/src/github.com/openshift/azure-file-csi-driver
 COPY . .
-RUN make azurefile
+RUN make azurefile ARCH=$(go env GOARCH)
 
 FROM registry.ci.openshift.org/ocp/4.11:base
 COPY --from=builder /go/src/github.com/openshift/azure-file-csi-driver/_output/amd64/azurefileplugin /bin/azurefileplugin


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The Makefile sets GOARCH?=amd64, which needs to be overridden for this image to build properly on other architectures.

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
