### PR TITLE
Dockerfile should copy binary for the correct ARCH

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,10 +1,10 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS builder
 WORKDIR /go/src/github.com/openshift/azure-file-csi-driver
 COPY . .
-RUN make azurefile ARCH=$(go env GOARCH)
+RUN make azurefile ARCH=$(go env GOARCH) && cp _output/$(go env GOARCH)/azurefileplugin .
 
 FROM registry.ci.openshift.org/ocp/4.11:base
-COPY --from=builder /go/src/github.com/openshift/azure-file-csi-driver/_output/amd64/azurefileplugin /bin/azurefileplugin
+COPY --from=builder /go/src/github.com/openshift/azure-file-csi-driver/azurefileplugin /bin/azurefileplugin
 RUN yum install -y cifs-utils util-linux nfs-utils e2fsprogs xfsprogs ca-certificates && yum clean all && rm -rf /var/cache/yum
 
 LABEL description="Azure File CSI Driver"


### PR DESCRIPTION
Follow up to https://github.com/openshift/azure-file-csi-driver/pull/9
[Brew builds for ARM](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=43231035) are failing because the Dockerfile is still hardcoded to copy the binary from _output/amd64.
/cc @openshift/storage 