### PR TITLE
UPSTREAM: <carry>: remove "replace" directive in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,5 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.21.0
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.21.0
 	k8s.io/sample-controller => k8s.io/sample-controller v0.21.0
-	sigs.k8s.io/azurefile-csi-driver => ./
 	sigs.k8s.io/cloud-provider-azure => sigs.k8s.io/cloud-provider-azure v0.7.1-0.20211103062220-cfbf336adc4e
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1012,5 +1012,4 @@ sigs.k8s.io/yaml
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.21.0
 # k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.21.0
 # k8s.io/sample-controller => k8s.io/sample-controller v0.21.0
-# sigs.k8s.io/azurefile-csi-driver => ./
 # sigs.k8s.io/cloud-provider-azure => sigs.k8s.io/cloud-provider-azure v0.7.1-0.20211103062220-cfbf336adc4e


### PR DESCRIPTION
The directive, that replaces this repository module with itsel, is causing builds to fail in go 1.17 and 1.18.

This change is intended to help with the go 1.18 migration in Cachito.

CC @openshift/storage 