### PR TITLE
OCPBUGS-27242: fix or ignore snyk errors for ocp storage repos

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - vendor/**
+    - hack/boilerplate/boilerplate.py


### PR DESCRIPTION
Ignore these two errors. boilerplate.py is only used to update the copyright headers, or to verify the headers during `make verify`. In either case, it does not grant the caller access to files that they would not already have access to.

```
 ✗ [Medium] Path Traversal
   ID: bbd44bf1-630b-4d40-b2db-86dc5d97c4b9 
   Path: hack/boilerplate/boilerplate.py, line 61 
   Info: Unsanitized input from a command line argument flows into open, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
 ✗ [Medium] Path Traversal
   ID: 452ba7c4-e865-4115-ae4d-9df9f142acd8 
   Path: hack/boilerplate/boilerplate.py, line 170 
   Info: Unsanitized input from a command line argument flows into os.walk, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.
```

from https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/47618/rehearse-47618-pull-ci-openshift-azure-file-csi-driver-master-security/1745954190884081664

/cc @openshift/storage
