### PR TITLE
STOR-1794: use azcopy base image to build driver

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -3,7 +3,8 @@ WORKDIR /go/src/github.com/openshift/azure-file-csi-driver
 COPY . .
 RUN make azurefile ARCH=$(go env GOARCH) && cp _output/$(go env GOARCH)/azurefileplugin .
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+# Use base image with azcopy installed
+FROM registry.ci.openshift.org/ocp/4.16:azure-storage-azcopy-base
 COPY --from=builder /go/src/github.com/openshift/azure-file-csi-driver/azurefileplugin /bin/azurefileplugin
 RUN yum install -y cifs-utils util-linux nfs-utils e2fsprogs xfsprogs ca-certificates && yum clean all && rm -rf /var/cache/yum
 

--- a/pkg/azurefile/azurefile.go
+++ b/pkg/azurefile/azurefile.go
@@ -386,6 +386,7 @@ func (d *Driver) Run(endpoint, kubeconfig string, testBool bool) {
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT,
 			csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
 			csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
+			csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 		})
 	d.AddVolumeCapabilityAccessModes([]csi.VolumeCapability_AccessMode_Mode{
 		csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,

--- a/pkg/csi-common/driver_test.go
+++ b/pkg/csi-common/driver_test.go
@@ -90,6 +90,7 @@ func TestValidateControllerServiceRequest(t *testing.T) {
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 			csi.ControllerServiceCapability_RPC_GET_CAPACITY,
 			csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
+			csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 		})
 
 	// Test controller service publish/unpublish is supported
@@ -108,6 +109,8 @@ func TestValidateControllerServiceRequest(t *testing.T) {
 	err = d.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_GET_CAPACITY)
 	assert.NoError(t, err)
 
+	// Test controller service clone volumes is supported
+	err = d.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CLONE_VOLUME)
 	assert.NoError(t, err)
 }
 

--- a/pkg/csi-common/utils_test.go
+++ b/pkg/csi-common/utils_test.go
@@ -201,6 +201,9 @@ func TestNewControllerServiceCapability(t *testing.T) {
 		{
 			cap: csi.ControllerServiceCapability_RPC_GET_CAPACITY,
 		},
+		{
+			cap: csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
+		},
 	}
 	for _, test := range tests {
 		resp := NewControllerServiceCapability(test.cap)


### PR DESCRIPTION
1. Use base image that includes `azcopy` cli
2. Revert commit that was disabling cloning capability: https://github.com/openshift/azure-file-csi-driver/pull/43/commits/1bde0d4cf550b6ddab7c086a7ab0546e578d79b6

Has to be merged after: https://github.com/openshift/csi-operator/pull/200