### PR TITLE
WIP: [release-4.13] OCPBUGS-41678: bump mount-utils to treat ENODEV error as corrupted mount

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -162,7 +162,7 @@ replace (
 	k8s.io/kubelet => k8s.io/kubelet v0.26.0
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.26.0
 	k8s.io/metrics => k8s.io/metrics v0.26.0
-	k8s.io/mount-utils => k8s.io/mount-utils v0.0.0-20230103133730-1df1a57439e2
+	k8s.io/mount-utils => github.com/dobsonj/mount-utils v0.0.0-20240910210000-cbd64886b2a9
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.26.0
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.26.0
 	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.1.0 h1:ReYa/UBrRyQdant9B4fNHGoCNKw6qh6P0fsdGmZpR7c=
+github.com/dobsonj/mount-utils v0.0.0-20240910210000-cbd64886b2a9 h1:Qh7s68PmKJ2XYjr/B8VxY/nx6x2vHV54lNkgDIvpp2I=
+github.com/dobsonj/mount-utils v0.0.0-20240910210000-cbd64886b2a9/go.mod h1:au99w4FWU5ZWelLb3Yx6kJc8RZ387IyWVM9tN65Yhxo=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -858,8 +860,6 @@ k8s.io/kubectl v0.26.0 h1:xmrzoKR9CyNdzxBmXV7jW9Ln8WMrwRK6hGbbf69o4T0=
 k8s.io/kubectl v0.26.0/go.mod h1:eInP0b+U9XUJWSYeU9XZnTA+cVYuWyl3iYPGtru0qhQ=
 k8s.io/kubernetes v1.26.0 h1:fL8VMr4xlfTazPORLhz5fsvO5I3bsFpmynVxZTH1ItQ=
 k8s.io/kubernetes v1.26.0/go.mod h1:z0aCJwn6DxzB/dDiWLbQaJO5jWOR2qoaCMnmSAx45XM=
-k8s.io/mount-utils v0.0.0-20230103133730-1df1a57439e2 h1:kfACKquxtsEA7XXDy+iC92lg/1stK0UtzAhf7R2Y8Fc=
-k8s.io/mount-utils v0.0.0-20230103133730-1df1a57439e2/go.mod h1:au99w4FWU5ZWelLb3Yx6kJc8RZ387IyWVM9tN65Yhxo=
 k8s.io/pod-security-admission v0.26.0 h1:XBG/uyP2cYwSFr5IWAQ1IIArxMYARJKzEzSmP4ZbC1s=
 k8s.io/pod-security-admission v0.26.0/go.mod h1:HQHvpCrn6KQLKRUqFvWkHCVKet3X62fn2F3j5anYiEM=
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/vendor/k8s.io/mount-utils/mount_helper_unix.go
+++ b/vendor/k8s.io/mount-utils/mount_helper_unix.go
@@ -58,7 +58,13 @@ func IsCorruptedMnt(err error) bool {
 		underlyingError = err
 	}
 
-	return underlyingError == syscall.ENOTCONN || underlyingError == syscall.ESTALE || underlyingError == syscall.EIO || underlyingError == syscall.EACCES || underlyingError == syscall.EHOSTDOWN
+	return errors.Is(underlyingError, syscall.ENOTCONN) ||
+		errors.Is(underlyingError, syscall.ESTALE) ||
+		errors.Is(underlyingError, syscall.EIO) ||
+		errors.Is(underlyingError, syscall.EACCES) ||
+		errors.Is(underlyingError, syscall.EHOSTDOWN) ||
+		errors.Is(underlyingError, syscall.EWOULDBLOCK) ||
+		errors.Is(underlyingError, syscall.ENODEV)
 }
 
 // MountInfo represents a single line in /proc/<pid>/mountinfo.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1194,7 +1194,7 @@ k8s.io/kubernetes/test/e2e/testing-manifests
 k8s.io/kubernetes/test/utils
 k8s.io/kubernetes/test/utils/image
 k8s.io/kubernetes/test/utils/kubeconfig
-# k8s.io/mount-utils v0.0.0 => k8s.io/mount-utils v0.0.0-20230103133730-1df1a57439e2
+# k8s.io/mount-utils v0.0.0 => github.com/dobsonj/mount-utils v0.0.0-20240910210000-cbd64886b2a9
 ## explicit; go 1.19
 k8s.io/mount-utils
 # k8s.io/pod-security-admission v0.26.0 => k8s.io/pod-security-admission v0.26.0
@@ -1320,7 +1320,7 @@ sigs.k8s.io/yaml
 # k8s.io/kubelet => k8s.io/kubelet v0.26.0
 # k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.26.0
 # k8s.io/metrics => k8s.io/metrics v0.26.0
-# k8s.io/mount-utils => k8s.io/mount-utils v0.0.0-20230103133730-1df1a57439e2
+# k8s.io/mount-utils => github.com/dobsonj/mount-utils v0.0.0-20240910210000-cbd64886b2a9
 # k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.26.0
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.26.0
 # k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.26.0


### PR DESCRIPTION
Alternate approach for https://github.com/openshift/azure-file-csi-driver/pull/81

This adds a replace directive pointing to a fork of mount-utils with the carry patch, then `go mod tidy && go mod vendor`.
