### PR TITLE
OCPBUGS-62664: UPSTREAM: <carry>: disable DeleteSnapshot in controller to prevent data loss

### DIFF
--- a/pkg/azurefile/controllerserver_test.go
+++ b/pkg/azurefile/controllerserver_test.go
@@ -2209,6 +2209,7 @@ func TestCreateSnapshot(t *testing.T) {
 }
 
 func TestDeleteSnapshot(t *testing.T) {
+	t.Skip("DeleteSnapshot functionality is disabled to prevent data loss (OCPBUGS-62547)")
 	d := NewFakeDriver()
 	d.cloud = &azure.Cloud{}
 


### PR DESCRIPTION
Has to be merged along with https://github.com/openshift/csi-operator/pull/459 (also contains verification steps)

This change breaks e2e tests, we should disable them first: https://github.com/openshift/csi-operator/pull/463

cc @openshift/storage 