### PR TITLE
OCPBUGS-70060: fix failing unit tests in azure-file-csi-driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ ARCH ?= amd64
 OSVERSION ?= 1809
 # Output type of docker buildx build
 OUTPUT_TYPE ?= registry
+# Set -short to skip cloud provider tests
+UNIT_TEST_ARGS ?=
 
 .EXPORT_ALL_VARIABLES:
 
@@ -76,7 +78,7 @@ verify: unit-test
 
 .PHONY: unit-test
 unit-test:
-	go test -v -race ./pkg/... ./test/utils/credentials -timeout=30m
+	go test -v -race $(UNIT_TEST_ARGS) ./pkg/... ./test/utils/credentials -timeout=30m
 
 .PHONY: sanity-test
 sanity-test: azurefile

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ verify: unit-test
 
 .PHONY: unit-test
 unit-test:
-	go test -v -race ./pkg/... ./test/utils/credentials
+	go test -v -race ./pkg/... ./test/utils/credentials -timeout=30m
 
 .PHONY: sanity-test
 sanity-test: azurefile

--- a/pkg/azurefile/azurefile_dataplane_client_test.go
+++ b/pkg/azurefile/azurefile_dataplane_client_test.go
@@ -25,6 +25,9 @@ import (
 )
 
 func TestCreateFileShare(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	testCases := []struct {
 		name     string
 		testFunc func(t *testing.T)
@@ -64,6 +67,9 @@ func TestNewAzureFileClient(t *testing.T) {
 }
 
 func TestDeleteFileShare(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	testCases := []struct {
 		name     string
 		testFunc func(t *testing.T)
@@ -90,6 +96,9 @@ func TestDeleteFileShare(t *testing.T) {
 }
 
 func TestResizeFileShare(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	testCases := []struct {
 		name     string
 		testFunc func(t *testing.T)
@@ -116,6 +125,9 @@ func TestResizeFileShare(t *testing.T) {
 }
 
 func TestGetFileShareQuotaDataPlane(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	testCases := []struct {
 		name     string
 		testFunc func(t *testing.T)

--- a/pkg/azurefile/azurefile_suite_test.go
+++ b/pkg/azurefile/azurefile_suite_test.go
@@ -24,6 +24,9 @@ import (
 )
 
 func TestAzurefile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "Azurefile Suite")
 }

--- a/pkg/azurefile/azurefile_test.go
+++ b/pkg/azurefile/azurefile_test.go
@@ -1828,6 +1828,9 @@ func TestIsSupportedPublicNetworkAccess(t *testing.T) {
 }
 
 func TestCreateFolderIfNotExists(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	d := NewFakeDriver()
 	ctx := context.Background()
 

--- a/pkg/azurefile/utils_test.go
+++ b/pkg/azurefile/utils_test.go
@@ -435,10 +435,12 @@ func TestChmodIfPermissionMismatch(t *testing.T) {
 	skipIfTestingOnWindows(t)
 	permissionMatchingPath, _ := getWorkDirPath("permissionMatchingPath")
 	_ = makeDir(permissionMatchingPath, 0755)
+	_ = os.Chmod(permissionMatchingPath, 0755&^os.ModeSetgid) // clear setgid bit
 	defer os.RemoveAll(permissionMatchingPath)
 
 	permissionMismatchPath, _ := getWorkDirPath("permissionMismatchPath")
 	_ = makeDir(permissionMismatchPath, 0721)
+	_ = os.Chmod(permissionMismatchPath, 0721&^os.ModeSetgid) // clear setgid bit
 	defer os.RemoveAll(permissionMismatchPath)
 
 	permissionMatchGidMismatchPath, _ := getWorkDirPath("permissionMatchGidMismatchPath")


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-70060

The unit tests are failing in https://github.com/openshift/azure-file-csi-driver/pull/111 -- this PR includes the following fixes:

- **test: fix unit test timeout**

This was already pushed upstream to increase the unit test timeout from 10m to 30m, including it here both to get past the timeout issue and also to avoid merge conflicts on the next patch.

- **test: add option to skip unit tests that block on cloud provider**

Some unit tests exercise back-end cloud provider functionality and take >1min to run per test, which can result in hitting the timeout. We already bumped the timeout, but we generally limit cloud provider tests to e2e, not unit tests. Ideally, it should be possible to run unit tests against the code without depending on availability of external services. This commit allows developers to optionally skip the long running tests with `make unit-test UNIT_TEST_ARGS=-short`.

After this merges, I can set this argument for the unit test job in openshift/release. (xref: https://github.com/openshift/release/pull/73464)

- **test: always chmod expected setgid bit in TestChmodIfPermissionMismatch**

TestChmodIfPermissionMismatch was failing 3 cases that expected setgid NOT to be set:

```
=== RUN   TestChmodIfPermissionMismatch
    utils_test.go:525: test[permission matching path]: unexpected gid bit: true, expected gid bit: false
    utils_test.go:525: test[permission mismatch path]: unexpected gid bit: true, expected gid bit: false
    utils_test.go:525: test[only change the permission mode bits when gid is not set but mode bits have gid set]: unexpected gid bit: true, expected gid bit: false
--- FAIL: TestChmodIfPermissionMismatch (0.00s)
```

The setgid bit was never specified and chmod was never called for these cases, so the test makes an assumption about the environment where it runs. This commit calls chmod to explicitly clear setgid for those test cases to avoid making assumptions about the default behavior.

/cc @openshift/storage