### PR TITLE
WIP: Optionally skip reading the config from the API server

### DIFF
--- a/pkg/azurefile/azure.go
+++ b/pkg/azurefile/azure.go
@@ -99,7 +99,7 @@ func getCloudProvider(ctx context.Context, kubeconfig, nodeID, secretName, secre
 		}
 	}
 
-	if kubeClient != nil {
+	if kubeClient != nil && secretName != "" && secretNamespace != "" {
 		klog.V(2).Infof("reading cloud config from secret %s/%s", secretNamespace, secretName)
 		config, err = configloader.Load[azureconfig.Config](ctx, &configloader.K8sSecretLoaderConfig{
 			K8sSecretConfig: configloader.K8sSecretConfig{
@@ -118,7 +118,11 @@ func getCloudProvider(ctx context.Context, kubeconfig, nodeID, secretName, secre
 	}
 
 	if config == nil {
-		klog.V(2).Infof("could not read cloud config from secret %s/%s", secretNamespace, secretName)
+		if secretName != "" || secretNamespace != "" {
+			klog.V(2).Infof("reading cloud config from a Kubernetes secret is disabled")
+		} else {
+			klog.V(2).Infof("could not read cloud config from secret %s/%s", secretNamespace, secretName)
+		}
 		credFile, ok := os.LookupEnv(DefaultAzureCredentialFileEnv)
 		if ok && strings.TrimSpace(credFile) != "" {
 			klog.V(2).Infof("%s env var set as %v", DefaultAzureCredentialFileEnv, credFile)

--- a/pkg/azurefile/azure_test.go
+++ b/pkg/azurefile/azure_test.go
@@ -268,7 +268,7 @@ users:
 			t.Setenv("AZURE_FEDERATED_TOKEN_FILE", test.aadFederatedTokenFile)
 		}
 
-		cloud, _, err := getCloudProvider(context.Background(), test.kubeconfig, "", "", "", test.userAgent, test.allowEmptyCloudConfig, false, 5, 10)
+		cloud, _, err := getCloudProvider(context.Background(), test.kubeconfig, "", "azure-cloud-provider", "kube-system", test.userAgent, test.allowEmptyCloudConfig, false, 5, 10)
 		if test.expectedErr.DefaultError != nil && test.expectedErr.WindowsError != nil {
 			if !testutil.AssertError(err, &test.expectedErr) && !strings.Contains(err.Error(), test.expectedErr.DefaultError.Error()) {
 				t.Errorf("desc: %s,\n input: %q, getCloudProvider err: %v, expectedErr: %v", test.desc, test.kubeconfig, err, test.expectedErr)


### PR DESCRIPTION
Testing before sending upstream.

Skip reading the driver configuration from the API server when -cloud-config-secret-name or -cloud-config-secret-namespace is explicitly set to an empty string.

The unit test change is technically not necessary - no unit test actually tries to get the Secret from provided namespace / name, it only make the unit test future proof once they start doing so.